### PR TITLE
Initialize Solution Structure and Fix Build Warnings

### DIFF
--- a/src/Meridian.Tests/DapploJiraTests.cs
+++ b/src/Meridian.Tests/DapploJiraTests.cs
@@ -15,7 +15,10 @@ class DapploJiraTests
     [Test]
     public async Task FieldsTest()
     {
-        IJiraClient jiraClient = JiraClient.Create(new Uri(Environment.GetEnvironmentVariable("JIRA_URL")));
+        var jiraUrl = Environment.GetEnvironmentVariable("JIRA_URL");
+        if (string.IsNullOrEmpty(jiraUrl)) Assert.Ignore("JIRA_URL environment variable is not set.");
+
+        IJiraClient jiraClient = JiraClient.Create(new Uri(jiraUrl!));
         jiraClient.SetBasicAuthentication(Environment.GetEnvironmentVariable("JIRA_USER"), Environment.GetEnvironmentVariable("JIRA_TOKEN"));
 
         var fields = await jiraClient.Server.GetFieldsAsync();
@@ -25,7 +28,10 @@ class DapploJiraTests
     [Test]
     public async Task SearchTest()
     {
-        var jiraClient = JiraClient.Create(new Uri(Environment.GetEnvironmentVariable("JIRA_URL")),
+        var jiraUrl = Environment.GetEnvironmentVariable("JIRA_URL");
+        if (string.IsNullOrEmpty(jiraUrl)) Assert.Ignore("JIRA_URL environment variable is not set.");
+
+        var jiraClient = JiraClient.Create(new Uri(jiraUrl!),
             new HttpSettings
             {
                 IgnoreSslCertificateErrors = true
@@ -50,7 +56,10 @@ class DapploJiraTests
     [Test]
     public async Task SprintsTest()
     {
-        var jiraClient = JiraClient.Create(new Uri(Environment.GetEnvironmentVariable("JIRA_URL")),
+        var jiraUrl = Environment.GetEnvironmentVariable("JIRA_URL");
+        if (string.IsNullOrEmpty(jiraUrl)) Assert.Ignore("JIRA_URL environment variable is not set.");
+
+        var jiraClient = JiraClient.Create(new Uri(jiraUrl!),
             new HttpSettings
             {
                 IgnoreSslCertificateErrors = true
@@ -72,7 +81,10 @@ class DapploJiraTests
         var author = "Khurram Aziz";
         var since = new DateTime(2025, 9, 29);
 
-        var jiraClient = JiraClient.Create(new Uri(Environment.GetEnvironmentVariable("JIRA_URL")),
+        var jiraUrl = Environment.GetEnvironmentVariable("JIRA_URL");
+        if (string.IsNullOrEmpty(jiraUrl)) Assert.Ignore("JIRA_URL environment variable is not set.");
+
+        var jiraClient = JiraClient.Create(new Uri(jiraUrl!),
             new HttpSettings
             {
                 IgnoreSslCertificateErrors = true

--- a/src/Meridian.Tests/NUnitLogger.cs
+++ b/src/Meridian.Tests/NUnitLogger.cs
@@ -5,7 +5,7 @@ namespace Meridian.Tests;
 
 internal class NUnitLogger<T> : ILogger<T>, IDisposable
 {
-    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
     {
         if (logLevel != LogLevel.Information)
             TestContext.Out.WriteLine($"{logLevel}: {state}");
@@ -15,7 +15,7 @@ internal class NUnitLogger<T> : ILogger<T>, IDisposable
 
     public bool IsEnabled(LogLevel logLevel) => true;
 
-    public IDisposable BeginScope<TState>(TState state) => this;
+    public IDisposable? BeginScope<TState>(TState state) where TState : notnull => this;
 
     public void Dispose() { }
 }

--- a/src/Meridian/Meridian.csproj
+++ b/src/Meridian/Meridian.csproj
@@ -6,13 +6,10 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
-  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Uworx.Meridian\Uworx.Meridian.csproj" />
+    <ProjectReference Include="..\Uworx.Meridian.Infrastructure\Uworx.Meridian.Infrastructure.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Uworx.Meridian.Infrastructure/Uworx.Meridian.Infrastructure.csproj
+++ b/src/Uworx.Meridian.Infrastructure/Uworx.Meridian.Infrastructure.csproj
@@ -11,4 +11,8 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\Uworx.Meridian\Uworx.Meridian.csproj" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
I have successfully initialized the solution structure for the Meridian project as requested in issue #1. 

Specifically, I:
1.  Established the correct project dependency graph (Domain ← Infrastructure ← Web).
2.  Cleaned up redundant package references in the web project.
3.  Fixed build warnings related to nullability and `ILogger` implementation in the test project.
4.  Ensured the test runner does not crash when environment variables are missing by using `Assert.Ignore` in `DapploJiraTests.cs`.
5.  Verified the fix by running `dotnet build Meridian.slnx`, which now exits with zero errors and zero warnings.
6.  Verified that `dotnet test Meridian.slnx` runs without crashing.

---
*PR created automatically by Jules for task [8940450388562658611](https://jules.google.com/task/8940450388562658611) started by @khurram-uworx*