### PR TITLE
Implement Course Source Resolver #4

### DIFF
--- a/src/Meridian.Tests/CourseSourceResolverTests.cs
+++ b/src/Meridian.Tests/CourseSourceResolverTests.cs
@@ -1,0 +1,187 @@
+using LibGit2Sharp;
+using NUnit.Framework;
+using Uworx.Meridian.CourseSource;
+using Uworx.Meridian.Infrastructure.CourseSource;
+
+namespace Meridian.Tests;
+
+[TestFixture]
+public class CourseSourceResolverTests
+{
+    private CourseSourceResolver _resolver;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _resolver = new CourseSourceResolver();
+    }
+
+    [Test]
+    public async Task ResolveAsync_LocalFolder_ReturnsSamePath()
+    {
+        // Arrange
+        var tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(tempPath);
+        try
+        {
+            var locator = new CourseSourceLocator(CourseSourceType.LocalFolder, tempPath);
+
+            // Act
+            var result = await _resolver.ResolveAsync(locator);
+
+            // Assert
+            Assert.That(result.FolderPath, Is.EqualTo(tempPath));
+            Assert.That(result.SourceRevision, Is.Null);
+        }
+        finally
+        {
+            if (Directory.Exists(tempPath))
+                Directory.Delete(tempPath);
+        }
+    }
+
+    [Test]
+    public void ResolveAsync_NonExistentLocalPath_ThrowsDirectoryNotFoundException()
+    {
+        // Arrange
+        var nonExistentPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        var locator = new CourseSourceLocator(CourseSourceType.LocalFolder, nonExistentPath);
+
+        // Act & Assert
+        Assert.ThrowsAsync<DirectoryNotFoundException>(async () => await _resolver.ResolveAsync(locator));
+    }
+
+    [Test]
+    public async Task ResolveAsync_GitRoot_ClonesAndReturnsPath()
+    {
+        // Arrange
+        var repoPath = Path.Combine(Path.GetTempPath(), "source-repo-" + Guid.NewGuid().ToString());
+        Directory.CreateDirectory(repoPath);
+        Repository.Init(repoPath);
+
+        using (var repo = new Repository(repoPath))
+        {
+            var filePath = Path.Combine(repoPath, "test.txt");
+            File.WriteAllText(filePath, "test content");
+            Commands.Stage(repo, "*");
+            var signature = new Signature("Tester", "tester@example.com", DateTimeOffset.Now);
+            var commit = repo.Commit("Initial commit", signature, signature);
+            var expectedSha = commit.Sha;
+
+            var locator = new CourseSourceLocator(CourseSourceType.GitRoot, repoPath);
+
+            // Act
+            var result = await _resolver.ResolveAsync(locator);
+
+            // Assert
+            try
+            {
+                Assert.That(Directory.Exists(result.FolderPath), Is.True);
+                Assert.That(File.Exists(Path.Combine(result.FolderPath, "test.txt")), Is.True);
+                Assert.That(result.SourceRevision, Is.EqualTo(expectedSha));
+            }
+            finally
+            {
+                // Cleanup temp clone
+                DeleteDirectory(result.FolderPath);
+            }
+        }
+
+        // Cleanup source repo
+        DeleteDirectory(repoPath);
+    }
+
+    [Test]
+    public async Task ResolveAsync_GitSubfolder_ReturnsSubfolderPath()
+    {
+        // Arrange
+        var repoPath = Path.Combine(Path.GetTempPath(), "source-repo-" + Guid.NewGuid().ToString());
+        Directory.CreateDirectory(repoPath);
+        Repository.Init(repoPath);
+
+        using (var repo = new Repository(repoPath))
+        {
+            var subfolder = "courses/c1";
+            var subfolderPath = Path.Combine(repoPath, subfolder);
+            Directory.CreateDirectory(subfolderPath);
+            File.WriteAllText(Path.Combine(subfolderPath, "course.yaml"), "title: Test");
+
+            Commands.Stage(repo, "*");
+            var signature = new Signature("Tester", "tester@example.com", DateTimeOffset.Now);
+            repo.Commit("Initial commit", signature, signature);
+
+            var locator = new CourseSourceLocator(CourseSourceType.GitSubfolder, repoPath, subfolder);
+
+            // Act
+            var result = await _resolver.ResolveAsync(locator);
+
+            // Assert
+            try
+            {
+                Assert.That(Directory.Exists(result.FolderPath), Is.True);
+                Assert.That(File.Exists(Path.Combine(result.FolderPath, "course.yaml")), Is.True);
+                Assert.That(result.FolderPath.EndsWith(subfolder.Replace('/', Path.DirectorySeparatorChar)), Is.True);
+            }
+            finally
+            {
+                // Get the root of the clone to delete it all
+                var cloneRoot = result.FolderPath.Substring(0, result.FolderPath.IndexOf(subfolder.Replace('/', Path.DirectorySeparatorChar)) - 1);
+                DeleteDirectory(cloneRoot);
+            }
+        }
+
+        DeleteDirectory(repoPath);
+    }
+
+    [Test]
+    public async Task ResolveAsync_GitSubfolder_InvalidPath_ThrowsArgumentException()
+    {
+        // Arrange
+        var repoPath = Path.Combine(Path.GetTempPath(), "source-repo-" + Guid.NewGuid().ToString());
+        Directory.CreateDirectory(repoPath);
+        Repository.Init(repoPath);
+
+        using (var repo = new Repository(repoPath))
+        {
+            var filePath = Path.Combine(repoPath, "test.txt");
+            File.WriteAllText(filePath, "test content");
+            Commands.Stage(repo, "*");
+            var signature = new Signature("Tester", "tester@example.com", DateTimeOffset.Now);
+            repo.Commit("Initial commit", signature, signature);
+
+            var locator = new CourseSourceLocator(CourseSourceType.GitSubfolder, repoPath, "../../etc/passwd");
+
+            // Act & Assert
+            Assert.ThrowsAsync<ArgumentException>(async () => await _resolver.ResolveAsync(locator));
+        }
+
+        DeleteDirectory(repoPath);
+    }
+
+    private static void DeleteDirectory(string path)
+    {
+        if (!Directory.Exists(path)) return;
+
+        // LibGit2Sharp leaves read-only files in .git folder, need to handle them
+        foreach (var directory in Directory.GetDirectories(path, "*", SearchOption.AllDirectories))
+        {
+            RemoveReadOnlyAttribute(directory);
+        }
+
+        foreach (var file in Directory.GetFiles(path, "*", SearchOption.AllDirectories))
+        {
+            RemoveReadOnlyAttribute(file);
+        }
+
+        Directory.Delete(path, true);
+    }
+
+    private static void RemoveReadOnlyAttribute(string path)
+    {
+        var attributes = File.GetAttributes(path);
+        if ((attributes & FileAttributes.ReadOnly) == FileAttributes.ReadOnly)
+        {
+            File.SetAttributes(path, attributes & ~FileAttributes.ReadOnly);
+        }
+    }
+}

--- a/src/Uworx.Meridian.Infrastructure/CourseSource/CourseSourceResolver.cs
+++ b/src/Uworx.Meridian.Infrastructure/CourseSource/CourseSourceResolver.cs
@@ -1,0 +1,65 @@
+using LibGit2Sharp;
+using Uworx.Meridian.CourseSource;
+
+namespace Uworx.Meridian.Infrastructure.CourseSource;
+
+public class CourseSourceResolver : ICourseSourceResolver
+{
+    public async Task<CourseSourceResult> ResolveAsync(CourseSourceLocator locator)
+    {
+        return locator.SourceType switch
+        {
+            CourseSourceType.LocalFolder => await ResolveLocalFolderAsync(locator),
+            CourseSourceType.GitRoot or CourseSourceType.GitSubfolder => await ResolveGitAsync(locator),
+            _ => throw new NotSupportedException($"Source type {locator.SourceType} is not supported.")
+        };
+    }
+
+    private Task<CourseSourceResult> ResolveLocalFolderAsync(CourseSourceLocator locator)
+    {
+        if (!Directory.Exists(locator.Uri))
+        {
+            throw new DirectoryNotFoundException($"Local folder not found: {locator.Uri}");
+        }
+
+        return Task.FromResult(new CourseSourceResult(locator.Uri, null));
+    }
+
+    private Task<CourseSourceResult> ResolveGitAsync(CourseSourceLocator locator)
+    {
+        var tempPath = Path.Combine(Path.GetTempPath(), "meridian", Guid.NewGuid().ToString());
+        Directory.CreateDirectory(tempPath);
+
+        Repository.Clone(locator.Uri, tempPath);
+
+        string? sourceRevision;
+        using (var repo = new Repository(tempPath))
+        {
+            sourceRevision = repo.Head.Tip.Sha;
+        }
+
+        var resolvedPath = tempPath;
+        if (locator.SourceType == CourseSourceType.GitSubfolder && !string.IsNullOrEmpty(locator.SubPath))
+        {
+            if (Path.IsPathRooted(locator.SubPath) || locator.SubPath.Contains(".."))
+            {
+                throw new ArgumentException("Invalid subpath provided.", nameof(locator));
+            }
+
+            resolvedPath = Path.GetFullPath(Path.Combine(tempPath, locator.SubPath));
+
+            // Safety check to ensure the resolved path is still within the temp directory
+            if (!resolvedPath.StartsWith(tempPath, StringComparison.OrdinalIgnoreCase))
+            {
+                throw new ArgumentException("Invalid subpath provided.", nameof(locator));
+            }
+
+            if (!Directory.Exists(resolvedPath))
+            {
+                throw new DirectoryNotFoundException($"Subfolder not found in Git repository: {locator.SubPath}");
+            }
+        }
+
+        return Task.FromResult(new CourseSourceResult(resolvedPath, sourceRevision));
+    }
+}

--- a/src/Uworx.Meridian.Infrastructure/Uworx.Meridian.Infrastructure.csproj
+++ b/src/Uworx.Meridian.Infrastructure/Uworx.Meridian.Infrastructure.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Dapplo.Jira" Version="2.0.7" />
+    <PackageReference Include="LibGit2Sharp" Version="0.31.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.5" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />

--- a/src/Uworx.Meridian/CourseSource/CourseSourceLocator.cs
+++ b/src/Uworx.Meridian/CourseSource/CourseSourceLocator.cs
@@ -1,0 +1,3 @@
+namespace Uworx.Meridian.CourseSource;
+
+public record CourseSourceLocator(CourseSourceType SourceType, string Uri, string? SubPath = null);

--- a/src/Uworx.Meridian/CourseSource/CourseSourceResult.cs
+++ b/src/Uworx.Meridian/CourseSource/CourseSourceResult.cs
@@ -1,0 +1,3 @@
+namespace Uworx.Meridian.CourseSource;
+
+public record CourseSourceResult(string FolderPath, string? SourceRevision);

--- a/src/Uworx.Meridian/CourseSource/CourseSourceType.cs
+++ b/src/Uworx.Meridian/CourseSource/CourseSourceType.cs
@@ -1,0 +1,8 @@
+namespace Uworx.Meridian.CourseSource;
+
+public enum CourseSourceType
+{
+    GitRoot,
+    GitSubfolder,
+    LocalFolder
+}

--- a/src/Uworx.Meridian/CourseSource/ICourseSourceResolver.cs
+++ b/src/Uworx.Meridian/CourseSource/ICourseSourceResolver.cs
@@ -1,0 +1,6 @@
+namespace Uworx.Meridian.CourseSource;
+
+public interface ICourseSourceResolver
+{
+    Task<CourseSourceResult> ResolveAsync(CourseSourceLocator locator);
+}


### PR DESCRIPTION
This PR implements the Course Source Resolver as described in issue #4. It supports resolving local folders, Git repository roots, and specific subfolders within Git repositories. It uses LibGit2Sharp for Git operations and includes path traversal validation and comprehensive unit tests.

---
*PR created automatically by Jules for task [6352885242871571267](https://jules.google.com/task/6352885242871571267) started by @khurram-uworx*