### PR TITLE
Implement Course Parsing Integration (Issue #7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ EF Core In-Memory for PoC. Migration to Postgres or SQL Server requires zero mod
 - [x] Parse `course.yaml` into `CourseConfig`
 - [x] Parse MD frontmatter (YAML) from each `.md` file into `SectionDefinition`
 - [x] Unit tests: given source type + course path, assert correct sections are parsed in order
+- [x] Integrated `ICourseParser` service
 
 ### Phase 2 — Enrollment & Jira Scaffolding
 - [ ] Jira service: `CreateEpic()`, `CreateStory(epicKey, title, description, storyPoints)`

--- a/src/Meridian.Tests/CourseParserTests.cs
+++ b/src/Meridian.Tests/CourseParserTests.cs
@@ -1,0 +1,72 @@
+using NUnit.Framework;
+using Uworx.Meridian.CourseSource;
+using Uworx.Meridian.Infrastructure.CourseSource;
+
+namespace Meridian.Tests;
+
+[TestFixture]
+public class CourseParserTests
+{
+    private string _tempCoursePath;
+    private CourseParser _parser;
+
+    [SetUp]
+    public void Setup()
+    {
+        _tempCoursePath = Path.Combine(Path.GetTempPath(), "meridian_parser_tests", Guid.NewGuid().ToString());
+        Directory.CreateDirectory(_tempCoursePath);
+
+        var sourceResolver = new CourseSourceResolver();
+        var configParser = new CourseConfigParser();
+        var sectionParser = new SectionParser();
+        _parser = new CourseParser(sourceResolver, configParser, sectionParser);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        if (Directory.Exists(_tempCoursePath))
+        {
+            Directory.Delete(_tempCoursePath, true);
+        }
+    }
+
+    [Test]
+    public async Task ParseAsync_LocalFolder_ReturnsFullyPopulatedParsedCourse()
+    {
+        // Arrange
+        var courseYaml = @"
+id: X101
+title: ""Test Course""
+jira_project: LEARN
+";
+        File.WriteAllText(Path.Combine(_tempCoursePath, "course.yaml"), courseYaml);
+
+        var section1 = @"---
+title: ""Section 1""
+order: 1
+---
+Content 1";
+        var section2 = @"---
+title: ""Section 2""
+order: 2
+---
+Content 2";
+        File.WriteAllText(Path.Combine(_tempCoursePath, "01-intro.md"), section1);
+        File.WriteAllText(Path.Combine(_tempCoursePath, "02-setup.md"), section2);
+
+        var locator = new CourseSourceLocator(CourseSourceType.LocalFolder, _tempCoursePath);
+
+        // Act
+        var result = await _parser.ParseAsync(locator);
+
+        // Assert
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.Config.Id, Is.EqualTo("X101"));
+        Assert.That(result.Config.Title, Is.EqualTo("Test Course"));
+        Assert.That(result.Sections.Count, Is.EqualTo(2));
+        Assert.That(result.Sections[0].Title, Is.EqualTo("Section 1"));
+        Assert.That(result.Sections[1].Title, Is.EqualTo("Section 2"));
+        Assert.That(result.SourceRevision, Is.Null);
+    }
+}

--- a/src/Meridian/Program.cs
+++ b/src/Meridian/Program.cs
@@ -1,5 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using Uworx.Meridian.Configuration;
+using Uworx.Meridian.CourseSource;
+using Uworx.Meridian.Infrastructure.CourseSource;
 using Uworx.Meridian.Infrastructure.Data;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -11,6 +13,11 @@ builder.Services.AddControllersWithViews();
 
 builder.Services.AddDbContext<MeridianDbContext>(options =>
     options.UseInMemoryDatabase("MeridianDb"));
+
+builder.Services.AddScoped<ICourseSourceResolver, CourseSourceResolver>();
+builder.Services.AddScoped<ICourseConfigParser, CourseConfigParser>();
+builder.Services.AddScoped<ISectionParser, SectionParser>();
+builder.Services.AddScoped<ICourseParser, CourseParser>();
 
 var app = builder.Build();
 

--- a/src/Uworx.Meridian.Infrastructure/CourseSource/CourseParser.cs
+++ b/src/Uworx.Meridian.Infrastructure/CourseSource/CourseParser.cs
@@ -1,0 +1,33 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Uworx.Meridian.CourseSource;
+
+namespace Uworx.Meridian.Infrastructure.CourseSource;
+
+public class CourseParser : ICourseParser
+{
+    private readonly ICourseSourceResolver _sourceResolver;
+    private readonly ICourseConfigParser _configParser;
+    private readonly ISectionParser _sectionParser;
+
+    public CourseParser(
+        ICourseSourceResolver sourceResolver,
+        ICourseConfigParser configParser,
+        ISectionParser sectionParser)
+    {
+        _sourceResolver = sourceResolver;
+        _configParser = configParser;
+        _sectionParser = sectionParser;
+    }
+
+    public async Task<ParsedCourse> ParseAsync(CourseSourceLocator locator)
+    {
+        var sourceResult = await _sourceResolver.ResolveAsync(locator);
+
+        var config = _configParser.Parse(sourceResult.FolderPath);
+        var sections = _sectionParser.ParseSections(sourceResult.FolderPath).ToList();
+
+        return new ParsedCourse(config, sections, sourceResult.SourceRevision);
+    }
+}

--- a/src/Uworx.Meridian/CourseSource/ICourseParser.cs
+++ b/src/Uworx.Meridian/CourseSource/ICourseParser.cs
@@ -1,0 +1,8 @@
+using System.Threading.Tasks;
+
+namespace Uworx.Meridian.CourseSource;
+
+public interface ICourseParser
+{
+    Task<ParsedCourse> ParseAsync(CourseSourceLocator locator);
+}

--- a/src/Uworx.Meridian/CourseSource/ParsedCourse.cs
+++ b/src/Uworx.Meridian/CourseSource/ParsedCourse.cs
@@ -1,0 +1,9 @@
+using System.Collections.Generic;
+
+namespace Uworx.Meridian.CourseSource;
+
+public record ParsedCourse(
+    CourseConfig Config,
+    IReadOnlyList<SectionDefinition> Sections,
+    string? SourceRevision
+);


### PR DESCRIPTION
This PR implements the `ICourseParser` service, which wires together the course source resolution, configuration parsing, and section parsing logic into a single entry point.

### Changes:
- **Domain (`Uworx.Meridian`)**: Added `ParsedCourse` record and `ICourseParser` interface.
- **Infrastructure (`Uworx.Meridian.Infrastructure`)**: Implemented `CourseParser`.
- **Web (`Meridian`)**: Registered the new service and its dependencies in `Program.cs`.
- **Tests (`Meridian.Tests`)**: Added `CourseParserTests` to verify the integration.
- **Documentation**: Updated `README.md` progress checklist.

All tests passed successfully.

---
*PR created automatically by Jules for task [9924542051006526308](https://jules.google.com/task/9924542051006526308) started by @khurram-uworx*