### PR TITLE
Implement Enrollment Flow (Issue #9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,8 +144,8 @@ EF Core In-Memory for PoC. Migration to Postgres or SQL Server requires zero mod
 
 ### Phase 2 — Enrollment & Jira Scaffolding
 - [x] Jira service: `CreateEpic()`, `CreateStory(epicKey, title, description, storyPoints, label)`
-- [ ] Enrollment flow: resolve source → parse → create Epic → loop sections → create Stories
-- [ ] Persist `Enrollment` record with `SourceRevision` (Git SHA or `null` for local folder) and `JiraEpicKey`
+- [x] Enrollment flow: resolve source → parse → create Epic → loop sections → create Stories
+- [x] Persist `Enrollment` record with `SourceRevision` (Git SHA or `null` for local folder) and `JiraEpicKey`
 - [ ] Simple Razor page: enroll form (learner email + source locator + optional course subpath) → confirm page showing Epic link
 
 ### Phase 3 — Quiz Flow

--- a/src/Meridian.Tests/EnrollmentServiceTests.cs
+++ b/src/Meridian.Tests/EnrollmentServiceTests.cs
@@ -1,0 +1,155 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NUnit.Framework;
+using Uworx.Meridian;
+using Uworx.Meridian.CourseSource;
+using Uworx.Meridian.Entities;
+using Uworx.Meridian.Infrastructure;
+using Uworx.Meridian.Infrastructure.Data;
+
+namespace Meridian.Tests;
+
+[TestFixture]
+public class EnrollmentServiceTests
+{
+    private MeridianDbContext _dbContext = null!;
+    private Mock<ICourseParser> _courseParserMock = null!;
+    private Mock<IJiraService> _jiraServiceMock = null!;
+    private Mock<ILogger<EnrollmentService>> _loggerMock = null!;
+    private EnrollmentService _enrollmentService = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        var options = new DbContextOptionsBuilder<MeridianDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+        _dbContext = new MeridianDbContext(options);
+
+        _courseParserMock = new Mock<ICourseParser>();
+        _jiraServiceMock = new Mock<IJiraService>();
+        _loggerMock = new Mock<ILogger<EnrollmentService>>();
+
+        _enrollmentService = new EnrollmentService(
+            _dbContext,
+            _courseParserMock.Object,
+            _jiraServiceMock.Object,
+            _loggerMock.Object);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _dbContext.Dispose();
+    }
+
+    [Test]
+    public async Task EnrollAsync_HappyPath_CreatesEverything()
+    {
+        // Arrange
+        var learnerEmail = "test@example.com";
+        var source = new CourseSourceLocator(CourseSourceType.LocalFolder, "/path/to/course");
+        var config = new CourseConfig("X102", "Test Course", "1.0", "Author", "LEARN", "meridian");
+        var sections = new List<SectionDefinition>
+        {
+            new SectionDefinition("Intro", 1, "lesson", 3, null, null, "Intro Body"),
+            new SectionDefinition("Setup", 2, "lesson", 5, null, null, "Setup Body")
+        };
+        var parsedCourse = new ParsedCourse(config, sections, "rev123");
+
+        _courseParserMock.Setup(p => p.ParseAsync(source))
+            .ReturnsAsync(parsedCourse);
+
+        _jiraServiceMock.Setup(j => j.CreateEpicAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync("LEARN-1");
+
+        _jiraServiceMock.Setup(j => j.CreateStoryAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>()))
+            .ReturnsAsync("LEARN-2");
+
+        // Act
+        var result = await _enrollmentService.EnrollAsync(learnerEmail, source);
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.JiraEpicKey, Is.EqualTo("LEARN-1"));
+            Assert.That(result.SourceRevision, Is.EqualTo("rev123"));
+
+            var learner = _dbContext.Learners.Single();
+            Assert.That(learner.Email, Is.EqualTo(learnerEmail));
+
+            var course = _dbContext.Courses.Single();
+            Assert.That(course.SourceLocator, Is.EqualTo(source.Uri));
+
+            var enrollment = _dbContext.Enrollments.Single();
+            Assert.That(enrollment.Id, Is.EqualTo(result.Id));
+        });
+
+        _jiraServiceMock.Verify(j => j.CreateEpicAsync("LEARN", "Test Course", "meridian"), Times.Once);
+        _jiraServiceMock.Verify(j => j.CreateStoryAsync("LEARN-1", It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>()), Times.Exactly(2));
+    }
+
+    [Test]
+    public async Task EnrollAsync_JiraStoryFails_DoesNotPersistEnrollment()
+    {
+        // Arrange
+        var learnerEmail = "test@example.com";
+        var source = new CourseSourceLocator(CourseSourceType.LocalFolder, "/path/to/course");
+        var config = new CourseConfig("X102", "Test Course", "1.0", "Author", "LEARN", "meridian");
+        var sections = new List<SectionDefinition>
+        {
+            new SectionDefinition("Intro", 1, "lesson", 3, null, null, "Intro Body"),
+            new SectionDefinition("Fail", 2, "lesson", 5, null, null, "Fail Body")
+        };
+        var parsedCourse = new ParsedCourse(config, sections, "rev123");
+
+        _courseParserMock.Setup(p => p.ParseAsync(source))
+            .ReturnsAsync(parsedCourse);
+
+        _jiraServiceMock.Setup(j => j.CreateEpicAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync("LEARN-1");
+
+        _jiraServiceMock.Setup(j => j.CreateStoryAsync(It.IsAny<string>(), "Intro", It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>()))
+            .ReturnsAsync("LEARN-2");
+
+        _jiraServiceMock.Setup(j => j.CreateStoryAsync(It.IsAny<string>(), "Fail", It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>()))
+            .ThrowsAsync(new Exception("Jira Error"));
+
+        // Act & Assert
+        Assert.ThrowsAsync<Exception>(async () => await _enrollmentService.EnrollAsync(learnerEmail, source));
+
+        Assert.That(_dbContext.Enrollments.Count(), Is.Zero);
+        // Learner and Course might be persisted because SaveChangesAsync is called before Jira operations
+        // and they are not part of the same transaction (In-Memory provider doesn't support transactions in the same way).
+        // However, the Enrollment record MUST NOT be there.
+    }
+
+    [Test]
+    public async Task EnrollAsync_LearnerUpsert_IsIdempotent()
+    {
+        // Arrange
+        var learnerEmail = "test@example.com";
+        _dbContext.Learners.Add(new Learner { Email = learnerEmail, Name = "Existing", JiraAccountId = "existing" });
+        await _dbContext.SaveChangesAsync();
+
+        var source = new CourseSourceLocator(CourseSourceType.LocalFolder, "/path/to/course");
+        var config = new CourseConfig("X102", "Test Course", "1.0", "Author", "LEARN", "meridian");
+        var sections = new List<SectionDefinition>();
+        var parsedCourse = new ParsedCourse(config, sections, "rev123");
+
+        _courseParserMock.Setup(p => p.ParseAsync(source))
+            .ReturnsAsync(parsedCourse);
+
+        _jiraServiceMock.Setup(j => j.CreateEpicAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync("LEARN-1");
+
+        // Act
+        await _enrollmentService.EnrollAsync(learnerEmail, source);
+
+        // Assert
+        Assert.That(_dbContext.Learners.Count(), Is.EqualTo(1));
+        Assert.That(_dbContext.Learners.Single().Email, Is.EqualTo(learnerEmail));
+    }
+}

--- a/src/Meridian/Program.cs
+++ b/src/Meridian/Program.cs
@@ -21,6 +21,7 @@ builder.Services.AddScoped<ICourseConfigParser, CourseConfigParser>();
 builder.Services.AddScoped<ISectionParser, SectionParser>();
 builder.Services.AddScoped<ICourseParser, CourseParser>();
 builder.Services.AddScoped<IJiraService, JiraService>();
+builder.Services.AddScoped<IEnrollmentService, EnrollmentService>();
 
 var app = builder.Build();
 

--- a/src/Uworx.Meridian.Infrastructure/EnrollmentService.cs
+++ b/src/Uworx.Meridian.Infrastructure/EnrollmentService.cs
@@ -1,0 +1,125 @@
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Uworx.Meridian.CourseSource;
+using Uworx.Meridian.Entities;
+using Uworx.Meridian.Infrastructure.Data;
+
+namespace Uworx.Meridian.Infrastructure;
+
+public class EnrollmentService : IEnrollmentService
+{
+    private readonly MeridianDbContext _dbContext;
+    private readonly ICourseParser _courseParser;
+    private readonly IJiraService _jiraService;
+    private readonly ILogger<EnrollmentService> _logger;
+
+    public EnrollmentService(
+        MeridianDbContext dbContext,
+        ICourseParser courseParser,
+        IJiraService jiraService,
+        ILogger<EnrollmentService> logger)
+    {
+        _dbContext = dbContext;
+        _courseParser = courseParser;
+        _jiraService = jiraService;
+        _logger = logger;
+    }
+
+    public async Task<Enrollment> EnrollAsync(string learnerEmail, CourseSourceLocator source)
+    {
+        // 1. Parse course
+        var parsedCourse = await _courseParser.ParseAsync(source);
+
+        // 2. Upsert Learner
+        var learner = await _dbContext.Learners
+            .FirstOrDefaultAsync(l => l.Email == learnerEmail);
+
+        if (learner == null)
+        {
+            learner = new Learner
+            {
+                Email = learnerEmail,
+                Name = learnerEmail.Split('@')[0], // Placeholder
+                JiraAccountId = learnerEmail // Placeholder
+            };
+            _dbContext.Learners.Add(learner);
+        }
+
+        // 3. Upsert Course
+        var course = await _dbContext.Courses
+            .FirstOrDefaultAsync(c => c.SourceType == source.SourceType.ToString() &&
+                                     c.SourceLocator == source.Uri &&
+                                     c.CoursePath == (source.SubPath ?? string.Empty));
+
+        var courseYamlSnapshot = JsonSerializer.Serialize(parsedCourse.Config);
+
+        if (course == null)
+        {
+            course = new Course
+            {
+                SourceType = source.SourceType.ToString(),
+                SourceLocator = source.Uri,
+                CoursePath = source.SubPath ?? string.Empty,
+                CourseYamlSnapshot = courseYamlSnapshot
+            };
+            _dbContext.Courses.Add(course);
+        }
+        else
+        {
+            course.CourseYamlSnapshot = courseYamlSnapshot;
+        }
+
+        await _dbContext.SaveChangesAsync();
+
+        // 4. Create Jira Epic
+        string epicKey;
+        try
+        {
+            epicKey = await _jiraService.CreateEpicAsync(
+                parsedCourse.Config.JiraProject,
+                parsedCourse.Config.Title,
+                parsedCourse.Config.EpicLabel ?? "meridian");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to create Jira Epic for {CourseTitle}", parsedCourse.Config.Title);
+            throw;
+        }
+
+        // 5. Create Jira Stories
+        try
+        {
+            foreach (var section in parsedCourse.Sections)
+            {
+                await _jiraService.CreateStoryAsync(
+                    epicKey,
+                    section.Title,
+                    section.BodyMarkdown,
+                    section.StoryPoints,
+                    section.Type);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to create Jira Stories for Epic {EpicKey}. Cleanup required.", epicKey);
+            // We don't delete the epic as per requirement (PoC), but we must ensure DB is not persisted.
+            throw;
+        }
+
+        // 6. Create Enrollment record
+        var enrollment = new Enrollment
+        {
+            LearnerId = learner.Id,
+            CourseId = course.Id,
+            JiraEpicKey = epicKey,
+            EnrolledAt = DateTime.UtcNow,
+            SourceRevision = parsedCourse.SourceRevision
+        };
+
+        _dbContext.Enrollments.Add(enrollment);
+        await _dbContext.SaveChangesAsync();
+
+        return enrollment;
+    }
+}

--- a/src/Uworx.Meridian/IEnrollmentService.cs
+++ b/src/Uworx.Meridian/IEnrollmentService.cs
@@ -1,0 +1,10 @@
+using System.Threading.Tasks;
+using Uworx.Meridian.CourseSource;
+using Uworx.Meridian.Entities;
+
+namespace Uworx.Meridian;
+
+public interface IEnrollmentService
+{
+    Task<Enrollment> EnrollAsync(string learnerEmail, CourseSourceLocator source);
+}


### PR DESCRIPTION
This PR implements the core enrollment flow for Meridian. It includes the logic to parse a course, upsert learner and course records in the database, scaffold the course structure in Jira (Epic and Stories), and finally persist an enrollment record. Atomicity is handled at the application level to ensure enrollment records are only saved if Jira operations succeed. Unit tests cover happy path, failure scenarios, and idempotency of learner creation.

---
*PR created automatically by Jules for task [883203198485375968](https://jules.google.com/task/883203198485375968) started by @khurram-uworx*