### PR TITLE
Implement Enrollment UI (Razor Page) #10

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,8 @@ The first working version does exactly this and nothing more:
   - Git repo root
   - Git repo subfolder (for example, `courses/course1`, `courses/course2`)
   - Absolute local folder path (for example, `C:\courses\course1`)
-- [ ] `POST /enroll` — takes learner + course source locator, resolves the course folder, records source revision when applicable, creates Jira Epic + Stories
-- [ ] Jira Stories get MD content as description + frontmatter mapped to fields
+- [x] `POST /enroll` — takes learner + course source locator, resolves the course folder, records source revision when applicable, creates Jira Epic + Stories
+- [x] Jira Stories get MD content as description + frontmatter mapped to fields
 - [ ] Quiz sections generate a Meridian-hosted link embedded in the ticket
 - [ ] Meridian quiz UI — MCQ, submit, write score back as Jira comment, transition ticket
 - [ ] Learner progress view — Meridian polls Jira for its known Epics and renders completion state
@@ -146,7 +146,7 @@ EF Core In-Memory for PoC. Migration to Postgres or SQL Server requires zero mod
 - [x] Jira service: `CreateEpic()`, `CreateStory(epicKey, title, description, storyPoints, label)`
 - [x] Enrollment flow: resolve source → parse → create Epic → loop sections → create Stories
 - [x] Persist `Enrollment` record with `SourceRevision` (Git SHA or `null` for local folder) and `JiraEpicKey`
-- [ ] Simple Razor page: enroll form (learner email + source locator + optional course subpath) → confirm page showing Epic link
+- [x] Simple Razor page: enroll form (learner email + source locator + optional course subpath) → confirm page showing Epic link
 
 ### Phase 3 — Quiz Flow
 - [ ] Quiz definition in MD frontmatter (question/options in YAML or linked JSON)

--- a/src/Meridian.Tests/EnrollmentControllerTests.cs
+++ b/src/Meridian.Tests/EnrollmentControllerTests.cs
@@ -1,0 +1,137 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using NUnit.Framework;
+using Meridian.Controllers;
+using Meridian.Models;
+using Uworx.Meridian;
+using Uworx.Meridian.Configuration;
+using Uworx.Meridian.CourseSource;
+using Uworx.Meridian.Entities;
+
+namespace Meridian.Tests;
+
+[TestFixture]
+public class EnrollmentControllerTests
+{
+    private Mock<IEnrollmentService> _enrollmentServiceMock = null!;
+    private Mock<IOptions<JiraOptions>> _jiraOptionsMock = null!;
+    private Mock<ILogger<EnrollmentController>> _loggerMock = null!;
+    private EnrollmentController _controller = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _enrollmentServiceMock = new Mock<IEnrollmentService>();
+        _jiraOptionsMock = new Mock<IOptions<JiraOptions>>();
+        _loggerMock = new Mock<ILogger<EnrollmentController>>();
+
+        _jiraOptionsMock.Setup(o => o.Value).Returns(new JiraOptions { BaseUrl = "https://jira.example.com" });
+
+        _controller = new EnrollmentController(
+            _enrollmentServiceMock.Object,
+            _jiraOptionsMock.Object,
+            _loggerMock.Object);
+    }
+
+    [Test]
+    public void Index_Get_ReturnsView()
+    {
+        // Act
+        var result = _controller.Index();
+
+        // Assert
+        Assert.That(result, Is.InstanceOf<ViewResult>());
+    }
+
+    [Test]
+    public async Task Index_Post_ValidModel_RedirectsToConfirm()
+    {
+        // Arrange
+        var model = new EnrollmentViewModel
+        {
+            LearnerEmail = "test@example.com",
+            SourceType = CourseSourceType.GitRoot,
+            SourceUri = "https://github.com/test/course"
+        };
+
+        var enrollment = new Enrollment { JiraEpicKey = "PROJ-1" };
+        _enrollmentServiceMock.Setup(s => s.EnrollAsync(model.LearnerEmail, It.IsAny<CourseSourceLocator>()))
+            .ReturnsAsync(enrollment);
+
+        // Act
+        var result = await _controller.Index(model);
+
+        // Assert
+        Assert.That(result, Is.InstanceOf<RedirectToActionResult>());
+        var redirectResult = (RedirectToActionResult)result;
+        Assert.That(redirectResult.ActionName, Is.EqualTo("Confirm"));
+        Assert.That(redirectResult.RouteValues?["epicKey"], Is.EqualTo("PROJ-1"));
+    }
+
+    [Test]
+    public async Task Index_Post_InvalidModel_ReturnsViewWithModel()
+    {
+        // Arrange
+        _controller.ModelState.AddModelError("LearnerEmail", "Required");
+        var model = new EnrollmentViewModel();
+
+        // Act
+        var result = await _controller.Index(model);
+
+        // Assert
+        Assert.That(result, Is.InstanceOf<ViewResult>());
+        var viewResult = (ViewResult)result;
+        Assert.That(viewResult.Model, Is.EqualTo(model));
+    }
+
+    [Test]
+    public async Task Index_Post_ServiceThrows_ReturnsViewWithError()
+    {
+        // Arrange
+        var model = new EnrollmentViewModel
+        {
+            LearnerEmail = "test@example.com",
+            SourceType = CourseSourceType.GitRoot,
+            SourceUri = "https://github.com/test/course"
+        };
+
+        _enrollmentServiceMock.Setup(s => s.EnrollAsync(model.LearnerEmail, It.IsAny<CourseSourceLocator>()))
+            .ThrowsAsync(new Exception("Something went wrong"));
+
+        // Act
+        var result = await _controller.Index(model);
+
+        // Assert
+        Assert.That(result, Is.InstanceOf<ViewResult>());
+        var viewResult = (ViewResult)result;
+        Assert.That(_controller.ModelState.IsValid, Is.False);
+        Assert.That(_controller.ModelState[string.Empty]?.Errors[0].ErrorMessage, Does.Contain("Something went wrong"));
+    }
+
+    [Test]
+    public void Confirm_ValidEpicKey_ReturnsViewWithData()
+    {
+        // Act
+        var result = _controller.Confirm("PROJ-1");
+
+        // Assert
+        Assert.That(result, Is.InstanceOf<ViewResult>());
+        var viewResult = (ViewResult)result;
+        Assert.That(viewResult.ViewData["EpicKey"], Is.EqualTo("PROJ-1"));
+        Assert.That(viewResult.ViewData["JiraBaseUrl"], Is.EqualTo("https://jira.example.com"));
+    }
+
+    [Test]
+    public void Confirm_EmptyEpicKey_RedirectsToIndex()
+    {
+        // Act
+        var result = _controller.Confirm(string.Empty);
+
+        // Assert
+        Assert.That(result, Is.InstanceOf<RedirectToActionResult>());
+        var redirectResult = (RedirectToActionResult)result;
+        Assert.That(redirectResult.ActionName, Is.EqualTo("Index"));
+    }
+}

--- a/src/Meridian.Tests/Meridian.Tests.csproj
+++ b/src/Meridian.Tests/Meridian.Tests.csproj
@@ -21,6 +21,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Meridian\Meridian.csproj" />
     <ProjectReference Include="..\Uworx.Meridian\Uworx.Meridian.csproj" />
     <ProjectReference Include="..\Uworx.Meridian.Infrastructure\Uworx.Meridian.Infrastructure.csproj" />
   </ItemGroup>

--- a/src/Meridian/Controllers/EnrollmentController.cs
+++ b/src/Meridian/Controllers/EnrollmentController.cs
@@ -1,0 +1,68 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+using Meridian.Models;
+using Uworx.Meridian;
+using Uworx.Meridian.Configuration;
+using Uworx.Meridian.CourseSource;
+
+namespace Meridian.Controllers;
+
+public class EnrollmentController : Controller
+{
+    private readonly IEnrollmentService _enrollmentService;
+    private readonly JiraOptions _jiraOptions;
+    private readonly ILogger<EnrollmentController> _logger;
+
+    public EnrollmentController(
+        IEnrollmentService enrollmentService,
+        IOptions<JiraOptions> jiraOptions,
+        ILogger<EnrollmentController> logger)
+    {
+        _enrollmentService = enrollmentService;
+        _jiraOptions = jiraOptions.Value;
+        _logger = logger;
+    }
+
+    [HttpGet("/enroll")]
+    public IActionResult Index()
+    {
+        return View();
+    }
+
+    [HttpPost("/enroll")]
+    public async Task<IActionResult> Index(EnrollmentViewModel model)
+    {
+        if (!ModelState.IsValid)
+        {
+            return View(model);
+        }
+
+        try
+        {
+            var source = new CourseSourceLocator(model.SourceType, model.SourceUri, model.SubPath);
+            var enrollment = await _enrollmentService.EnrollAsync(model.LearnerEmail, source);
+
+            return RedirectToAction(nameof(Confirm), new { epicKey = enrollment.JiraEpicKey });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error during enrollment for {Email}", model.LearnerEmail);
+            ModelState.AddModelError(string.Empty, $"An error occurred during enrollment: {ex.Message}");
+            return View(model);
+        }
+    }
+
+    [HttpGet("/enroll/confirm")]
+    public IActionResult Confirm(string epicKey)
+    {
+        if (string.IsNullOrEmpty(epicKey))
+        {
+            return RedirectToAction(nameof(Index));
+        }
+
+        ViewData["EpicKey"] = epicKey;
+        ViewData["JiraBaseUrl"] = _jiraOptions.BaseUrl;
+
+        return View();
+    }
+}

--- a/src/Meridian/Models/EnrollmentViewModel.cs
+++ b/src/Meridian/Models/EnrollmentViewModel.cs
@@ -1,0 +1,23 @@
+using System.ComponentModel.DataAnnotations;
+using Uworx.Meridian.CourseSource;
+
+namespace Meridian.Models;
+
+public class EnrollmentViewModel
+{
+    [Required]
+    [EmailAddress]
+    [Display(Name = "Learner Email")]
+    public string LearnerEmail { get; set; } = string.Empty;
+
+    [Required]
+    [Display(Name = "Source Type")]
+    public CourseSourceType SourceType { get; set; }
+
+    [Required]
+    [Display(Name = "Source URI")]
+    public string SourceUri { get; set; } = string.Empty;
+
+    [Display(Name = "Sub-path (optional)")]
+    public string? SubPath { get; set; }
+}

--- a/src/Meridian/Views/Enrollment/Confirm.cshtml
+++ b/src/Meridian/Views/Enrollment/Confirm.cshtml
@@ -1,0 +1,27 @@
+@{
+    ViewData["Title"] = "Enrollment Successful";
+    var epicKey = ViewData["EpicKey"] as string;
+    var jiraBaseUrl = ViewData["JiraBaseUrl"] as string;
+    var jiraLink = $"{jiraBaseUrl?.TrimEnd('/')}/browse/{epicKey}";
+}
+
+<div class="text-center">
+    <h1 class="display-4 text-success">Enrollment Successful!</h1>
+    <p class="lead">Your learning journey has been scaffolded in Jira.</p>
+
+    <div class="card mt-4 mx-auto" style="max-width: 500px;">
+        <div class="card-body">
+            <h5 class="card-title">Jira Epic</h5>
+            <p class="card-text">
+                Your progress will be tracked in the following Jira Epic:
+            </p>
+            <a href="@jiraLink" target="_blank" class="btn btn-outline-primary btn-lg">
+                @epicKey
+            </a>
+        </div>
+    </div>
+
+    <div class="mt-4">
+        <a asp-controller="Home" asp-action="Index" class="btn btn-link">Back to Home</a>
+    </div>
+</div>

--- a/src/Meridian/Views/Enrollment/Index.cshtml
+++ b/src/Meridian/Views/Enrollment/Index.cshtml
@@ -1,0 +1,44 @@
+@using Uworx.Meridian.CourseSource
+@model Meridian.Models.EnrollmentViewModel
+
+@{
+    ViewData["Title"] = "Enroll in a Course";
+}
+
+<h1>Enroll in a Course</h1>
+
+<div class="row">
+    <div class="col-md-6">
+        <form asp-action="Index" method="post">
+            <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+
+            <div class="form-group mb-3">
+                <label asp-for="LearnerEmail" class="form-label"></label>
+                <input asp-for="LearnerEmail" class="form-control" />
+                <span asp-validation-for="LearnerEmail" class="text-danger"></span>
+            </div>
+
+            <div class="form-group mb-3">
+                <label asp-for="SourceType" class="form-label"></label>
+                <select asp-for="SourceType" class="form-select" asp-items="Html.GetEnumSelectList<CourseSourceType>()"></select>
+                <span asp-validation-for="SourceType" class="text-danger"></span>
+            </div>
+
+            <div class="form-group mb-3">
+                <label asp-for="SourceUri" class="form-label"></label>
+                <input asp-for="SourceUri" class="form-control" placeholder="e.g., https://github.com/... or C:\courses\..." />
+                <span asp-validation-for="SourceUri" class="text-danger"></span>
+            </div>
+
+            <div class="form-group mb-3">
+                <label asp-for="SubPath" class="form-label"></label>
+                <input asp-for="SubPath" class="form-control" placeholder="Optional sub-path within the source" />
+                <span asp-validation-for="SubPath" class="text-danger"></span>
+            </div>
+
+            <div class="form-group">
+                <button type="submit" class="btn btn-primary">Enroll Now</button>
+            </div>
+        </form>
+    </div>
+</div>

--- a/src/Meridian/Views/Shared/_Layout.cshtml
+++ b/src/Meridian/Views/Shared/_Layout.cshtml
@@ -24,6 +24,9 @@
                             <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="Index">Home</a>
                         </li>
                         <li class="nav-item">
+                            <a class="nav-link text-dark" asp-area="" asp-controller="Enrollment" asp-action="Index">Enroll</a>
+                        </li>
+                        <li class="nav-item">
                             <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="Privacy">Privacy</a>
                         </li>
                     </ul>


### PR DESCRIPTION
This PR implements the Enrollment UI as a Razor Page in the Meridian application. It includes a form for users to enter learner email, source type, source URI, and an optional sub-path. Upon successful enrollment, users are redirected to a confirmation page that displays a link to the created Jira Epic. Inline validation and error handling are included. Unit tests for the new controller have been added and verified.

---
*PR created automatically by Jules for task [125835232874782180](https://jules.google.com/task/125835232874782180) started by @khurram-uworx*