### PR TITLE
Implement Quiz Definition Format #11

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ EF Core In-Memory for PoC. Migration to Postgres or SQL Server requires zero mod
 - [x] Simple Razor page: enroll form (learner email + source locator + optional course subpath) → confirm page showing Epic link
 
 ### Phase 3 — Quiz Flow
-- [ ] Quiz definition in MD frontmatter (question/options in YAML or linked JSON)
+- [x] Quiz definition in MD frontmatter (question/options in YAML or linked JSON)
 - [ ] Meridian quiz UI: `/quiz/{quizId}?enrollment={id}` — render MCQs, submit
 - [ ] On submit: calculate score, POST comment to Jira ticket, transition ticket to Done
 - [ ] Persist `QuizAttempt`

--- a/src/Meridian.Tests/CourseParserTests.cs
+++ b/src/Meridian.Tests/CourseParserTests.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Logging.Abstractions;
 using NUnit.Framework;
 using Uworx.Meridian.CourseSource;
 using Uworx.Meridian.Infrastructure.CourseSource;
@@ -18,7 +19,7 @@ public class CourseParserTests
 
         var sourceResolver = new CourseSourceResolver();
         var configParser = new CourseConfigParser();
-        var sectionParser = new SectionParser();
+        var sectionParser = new SectionParser(NullLogger<SectionParser>.Instance);
         _parser = new CourseParser(sourceResolver, configParser, sectionParser);
     }
 

--- a/src/Meridian.Tests/SectionParserTests.cs
+++ b/src/Meridian.Tests/SectionParserTests.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Logging.Abstractions;
 using NUnit.Framework;
 using Uworx.Meridian.Infrastructure.CourseSource;
 
@@ -14,7 +15,7 @@ public class SectionParserTests
     {
         _tempCoursePath = Path.Combine(Path.GetTempPath(), "meridian_section_tests", Guid.NewGuid().ToString());
         Directory.CreateDirectory(_tempCoursePath);
-        _parser = new SectionParser();
+        _parser = new SectionParser(NullLogger<SectionParser>.Instance);
     }
 
     [TearDown]
@@ -119,5 +120,64 @@ Even more dashes.";
 
         // Assert
         Assert.That(result[0].BodyMarkdown, Is.EqualTo("This is the body.\nIt has multiple lines.\n---\nEven more dashes."));
+    }
+
+    [Test]
+    public void ParseSections_WithQuizQuestions_PopulatesQuizQuestions()
+    {
+        // Arrange
+        var content = @"---
+title: ""Quiz Time""
+type: quiz
+quiz_questions:
+  - text: ""What is 2+2?""
+    options: [""3"", ""4"", ""5""]
+    correct_index: 1
+  - text: ""What is the capital of France?""
+    options: [""London"", ""Berlin"", ""Paris""]
+    correct_index: 2
+---
+Good luck!";
+        File.WriteAllText(Path.Combine(_tempCoursePath, "quiz.md"), content);
+
+        // Act
+        var result = _parser.ParseSections(_tempCoursePath).ToList();
+
+        // Assert
+        Assert.That(result.Count, Is.EqualTo(1));
+        var section = result[0];
+        Assert.That(section.Type, Is.EqualTo("quiz"));
+        Assert.That(section.QuizQuestions.Count(), Is.EqualTo(2));
+
+        var q1 = section.QuizQuestions.First();
+        Assert.That(q1.Text, Is.EqualTo("What is 2+2?"));
+        Assert.That(q1.Options.Count, Is.EqualTo(3));
+        Assert.That(q1.Options[1], Is.EqualTo("4"));
+        Assert.That(q1.CorrectIndex, Is.EqualTo(1));
+
+        var q2 = section.QuizQuestions.Last();
+        Assert.That(q2.Text, Is.EqualTo("What is the capital of France?"));
+        Assert.That(q2.CorrectIndex, Is.EqualTo(2));
+    }
+
+    [Test]
+    public void ParseSections_TypeQuizWithNoQuestions_LogsWarningAndSetsTypeToLesson()
+    {
+        // Arrange
+        var content = @"---
+title: ""Empty Quiz""
+type: quiz
+---
+Wait, where are the questions?";
+        File.WriteAllText(Path.Combine(_tempCoursePath, "empty-quiz.md"), content);
+
+        // Act
+        var result = _parser.ParseSections(_tempCoursePath).ToList();
+
+        // Assert
+        Assert.That(result.Count, Is.EqualTo(1));
+        var section = result[0];
+        Assert.That(section.Type, Is.EqualTo("lesson"));
+        Assert.That(section.QuizQuestions.Count(), Is.EqualTo(0));
     }
 }

--- a/src/Uworx.Meridian.Infrastructure/CourseSource/SectionParser.cs
+++ b/src/Uworx.Meridian.Infrastructure/CourseSource/SectionParser.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using Microsoft.Extensions.Logging;
 using Uworx.Meridian.CourseSource;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
@@ -8,9 +9,11 @@ namespace Uworx.Meridian.Infrastructure.CourseSource;
 public class SectionParser : ISectionParser
 {
     private readonly IDeserializer _deserializer;
+    private readonly ILogger<SectionParser> _logger;
 
-    public SectionParser()
+    public SectionParser(ILogger<SectionParser> logger)
     {
+        _logger = logger;
         _deserializer = new DeserializerBuilder()
             .WithNamingConvention(UnderscoredNamingConvention.Instance)
             .IgnoreUnmatchedProperties()
@@ -48,6 +51,17 @@ public class SectionParser : ISectionParser
             var storyPoints = dto?.StoryPoints ?? 0;
             var quizId = dto?.Quiz;
             var dependsOn = dto?.DependsOn;
+            var quizQuestions = dto?.QuizQuestions?.Select(q => new QuizQuestion(
+                q.Text ?? string.Empty,
+                q.Options ?? new List<string>(),
+                q.CorrectIndex ?? 0
+            )).ToList() ?? new List<QuizQuestion>();
+
+            if (type == "quiz" && !quizQuestions.Any())
+            {
+                _logger.LogWarning("Section {FileName} has type 'quiz' but no quiz_questions defined. Treating as 'lesson'.", fileName);
+                type = "lesson";
+            }
 
             sections.Add(new SectionDefinition(
                 title,
@@ -56,7 +70,8 @@ public class SectionParser : ISectionParser
                 storyPoints,
                 quizId,
                 dependsOn,
-                body.Trim()
+                body.Trim(),
+                quizQuestions
             ));
         }
 
@@ -104,5 +119,13 @@ public class SectionParser : ISectionParser
         public int? StoryPoints { get; set; }
         public string? Quiz { get; set; }
         public string? DependsOn { get; set; }
+        public List<QuizQuestionDto>? QuizQuestions { get; set; }
+    }
+
+    private class QuizQuestionDto
+    {
+        public string? Text { get; set; }
+        public List<string>? Options { get; set; }
+        public int? CorrectIndex { get; set; }
     }
 }

--- a/src/Uworx.Meridian/CourseSource/QuizQuestion.cs
+++ b/src/Uworx.Meridian/CourseSource/QuizQuestion.cs
@@ -1,0 +1,5 @@
+using System.Collections.Generic;
+
+namespace Uworx.Meridian.CourseSource;
+
+public record QuizQuestion(string Text, List<string> Options, int CorrectIndex);

--- a/src/Uworx.Meridian/CourseSource/SectionDefinition.cs
+++ b/src/Uworx.Meridian/CourseSource/SectionDefinition.cs
@@ -7,5 +7,9 @@ public record SectionDefinition(
     int StoryPoints,
     string? QuizId,
     string? DependsOn,
-    string BodyMarkdown
-);
+    string BodyMarkdown,
+    IEnumerable<QuizQuestion>? QuizQuestions = null
+)
+{
+    public IEnumerable<QuizQuestion> QuizQuestions { get; init; } = QuizQuestions ?? [];
+}


### PR DESCRIPTION
This PR implements the quiz definition format as specified in issue #11. 

Changes include:
- A new `QuizQuestion` record in the domain layer.
- Updated `SectionDefinition` to include an optional list of `QuizQuestions`.
- Enhanced `SectionParser` in the infrastructure layer to handle the `quiz_questions` YAML block.
- Fallback logic to treat sections of type `quiz` as `lesson` if no questions are defined, with appropriate logging.
- Unit tests in `SectionParserTests` covering both successful parsing and the fallback scenario.
- Updated `README.md` to track progress.

---
*PR created automatically by Jules for task [8988165379852434403](https://jules.google.com/task/8988165379852434403) started by @khurram-uworx*